### PR TITLE
null check & Spotify Token Refresh

### DIFF
--- a/NowPlaying/MainModel.cs
+++ b/NowPlaying/MainModel.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/NowPlaying/MainModel.cs
+++ b/NowPlaying/MainModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -125,7 +125,7 @@ namespace NowPlaying
                     playing = await Spotify.GetCurrentlyPlaying();
                 }
                 if (misskey.i == "") return;
-                if (playing == null) return;
+                if (playing == null || playing.Item == null) return;
                 SpotifyAPI.Web.FullTrack track = (SpotifyAPI.Web.FullTrack)playing.Item;
                 string artists = "";
                 foreach (var artist in track.Artists)
@@ -178,7 +178,7 @@ namespace NowPlaying
             if (!Spotify.IsGetToken) return;
 
             SpotifyAPI.Web.CurrentlyPlaying playing = await Spotify.GetCurrentlyPlaying();
-            if (playing != null)
+            if (playing != null && playing.Item != null)
             {
                 if (playing.Item.Type == SpotifyAPI.Web.ItemType.Track)
                 {

--- a/NowPlaying/Spotify.cs
+++ b/NowPlaying/Spotify.cs
@@ -96,7 +96,15 @@ namespace NowPlaying
         public async Task<CurrentlyPlaying> GetCurrentlyPlaying()
         {
             if (spotifyClient == null) return Playing;
-            Playing = await spotifyClient.Player.GetCurrentlyPlaying(new PlayerCurrentlyPlayingRequest(PlayerCurrentlyPlayingRequest.AdditionalTypes.Track));
+            try
+            {
+                Playing = await spotifyClient.Player.GetCurrentlyPlaying(new PlayerCurrentlyPlayingRequest(PlayerCurrentlyPlayingRequest.AdditionalTypes.Track));
+            }
+            catch (APIUnauthorizedException e)
+            {
+                await RefreshToken();
+                Playing = await spotifyClient.Player.GetCurrentlyPlaying(new PlayerCurrentlyPlayingRequest(PlayerCurrentlyPlayingRequest.AdditionalTypes.Track));
+            }
             return Playing;
         }
 

--- a/NowPlaying/Spotify.cs
+++ b/NowPlaying/Spotify.cs
@@ -1,4 +1,4 @@
-﻿using SpotifyAPI.Web;
+using SpotifyAPI.Web;
 using SpotifyAPI.Web.Auth;
 using System;
 using System.Collections.Generic;
@@ -112,7 +112,7 @@ namespace NowPlaying
         }
         public async Task PlayResume()
         {
-            if (spotifyClient == null) return;
+            if (spotifyClient == null && Playing == null) return;
             //Playing = await spotifyClient.Player.GetCurrentlyPlaying(new PlayerCurrentlyPlayingRequest(PlayerCurrentlyPlayingRequest.AdditionalTypes.Track));
             if (Playing.IsPlaying)
             {


### PR DESCRIPTION
長時間起動でSpotify のTokenが期限切れになり、落ちる問題を修正